### PR TITLE
feat: show DTO payload in order LogEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,15 @@ curl -X POST http://localhost:8081/orders \
 
 Expected `LOG_EVENT.eventName`: `orderCreated`
 
-Expected top-level payload fields:
+Expected top-level payload fields. The service receives `OrderRequest` as a DTO, so the SDK keeps it as one object value instead of flattening it:
 
 ```json
 {
-  "productId": "PROD-1",
-  "quantity": 2,
-  "userId": "USR-1"
+  "request": {
+    "productId": "PROD-1",
+    "quantity": 2,
+    "userId": "USR-1"
+  }
 }
 ```
 
@@ -156,7 +158,7 @@ fun register(name: String, @LogMasked email: String): String
 
 The SDK skips invalid `LOG_EVENT.eventName` values and leaves a warning in the target app log. Dotted names such as `user.registered` are intentionally not used by this example.
 
-Method parameter names become top-level `LOG_EVENT.payload` keys. DTOs are not flattened by the SDK contract.
+Method parameter names become top-level `LOG_EVENT.payload` keys. DTOs are not flattened by the SDK contract. For example, `OrderService.create(request: OrderRequest)` is sent as top-level `request`.
 
 ## LogSpec And Log Catalog
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("com.github.log-freind:log-friends-sdk:v1.3.0")
+    implementation("com.github.log-freind:log-friends-sdk:v0.1.0")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")

--- a/docs/log-catalog.md
+++ b/docs/log-catalog.md
@@ -50,9 +50,7 @@ curl -X PUT http://localhost:8082/api/log-specs/by-agent/<agentId> \
         "levels": ["INFO"],
         "category": "BUSINESS",
         "fields": [
-          {"name":"productId","type":"STRING","required":true,"description":"Product id"},
-          {"name":"quantity","type":"INTEGER","required":true,"description":"Ordered quantity"},
-          {"name":"userId","type":"STRING","required":true,"description":"Purchasing user id"}
+          {"name":"request","type":"JSON","required":true,"description":"OrderRequest DTO object. SDK keeps DTO parameters as object values instead of flattening fields"}
         ]
       },
       {
@@ -131,6 +129,6 @@ Check:
 
 ## 5. See A Mismatch
 
-Add a required `couponId` field to the `orderCreated` LogSpec and upsert it again without changing the example app. The next Catalog response should show a `MISSING_FIELD` mismatch because the sample payload has no `couponId`.
+Add a required top-level `couponId` field to the `orderCreated` LogSpec and upsert it again without changing the example app. The next Catalog response should show a `MISSING_FIELD` mismatch because the sample payload has top-level `request`, not `couponId`.
 
 Field Request belongs to Console state. This example guide does not create Jira, Linear, or GitHub tickets.

--- a/src/main/kotlin/com/example/demo/order/OrderController.kt
+++ b/src/main/kotlin/com/example/demo/order/OrderController.kt
@@ -9,7 +9,7 @@ class OrderController(private val orderService: OrderService) {
 
     @PostMapping
     fun create(@RequestBody request: OrderRequest): ResponseEntity<String> {
-        val orderId = orderService.create(request.productId, request.quantity, request.userId)
+        val orderId = orderService.create(request)
         return ResponseEntity.ok(orderId)
     }
 

--- a/src/main/kotlin/com/example/demo/order/OrderService.kt
+++ b/src/main/kotlin/com/example/demo/order/OrderService.kt
@@ -11,10 +11,10 @@ class OrderService(
     private val log = LoggerFactory.getLogger(OrderService::class.java)
 
     @LogEvent("orderCreated")
-    fun create(productId: String, quantity: Int, userId: String): String {
-        log.info("Creating order for product {}, user {}", productId, userId)
+    fun create(request: OrderRequest): String {
+        log.info("Creating order for product {}, user {}", request.productId, request.userId)
         val orderId = "ORD-" + System.currentTimeMillis()
-        orderAuditRepository.recordCreated(orderId, productId, quantity, userId)
+        orderAuditRepository.recordCreated(orderId, request.productId, request.quantity, request.userId)
         return orderId
     }
 

--- a/src/test/kotlin/com/example/demo/order/OrderControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/order/OrderControllerTest.kt
@@ -19,7 +19,7 @@ class OrderControllerTest {
 
     @Test
     fun `POST orders - 유효한 요청은 200과 orderId 반환`() {
-        given(orderService.create("PROD-1", 2, "USR-001")).willReturn("ORD-123")
+        given(orderService.create(OrderRequest("PROD-1", 2, "USR-001"))).willReturn("ORD-123")
 
         mockMvc.perform(
             post("/orders")
@@ -53,7 +53,7 @@ class OrderControllerTest {
 
     @Test
     fun `POST orders - 수량 1이상이면 정상 처리`() {
-        given(orderService.create("PROD-2", 1, "USR-002")).willReturn("ORD-456")
+        given(orderService.create(OrderRequest("PROD-2", 1, "USR-002"))).willReturn("ORD-456")
 
         mockMvc.perform(
             post("/orders")


### PR DESCRIPTION
## Summary
- update examples to consume log-friends-sdk v0.1.0
- pass OrderRequest DTO directly into the orderCreated LogEvent method
- document that DTO parameters are sent as top-level object payload values instead of flattened fields

## Verification
- ./gradlew build