### PR TITLE
docs: align local ingest port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 ./gradlew build
 ./gradlew bootJar
 
-LOGFRIENDS_INGEST_URL=http://localhost:8082/ingest \
+LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
 java -Djdk.attach.allowAttachSelf=true \
      -jar build/libs/examples.jar

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ This branch uses the SDK `main` baseline that enforces required configuration, c
 
 ```bash
 export LOGFRIENDS_WORKER_ID=order-service-local-1
-export LOGFRIENDS_INGEST_URL=http://localhost:8082/ingest
+export LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest
 ```
 
 `workerId` identifies the running app instance. Do not generate a new value on every run if you want Console Agent metadata and statistics to stay connected.
 
-`application.properties` keeps `order-service-local-1` and `http://localhost:8082/ingest` as local example fallbacks. Set the environment variables explicitly when verifying Console integration.
+`application.properties` keeps `order-service-local-1` and `http://localhost:8080/ingest` as local example fallbacks. Set the environment variables explicitly when verifying Console integration.
 
 ## Run With Console
 
-Start a Console that can receive ingest requests at `http://localhost:8082/ingest` first.
+Start a Console that can receive ingest requests at `http://localhost:8080/ingest` first.
 
 Run the example app:
 
@@ -49,7 +49,7 @@ Run the example app:
 git clone https://github.com/log-freind/log-friends-examples.git
 cd log-friends-examples
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
-LOGFRIENDS_INGEST_URL=http://localhost:8082/ingest \
+LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 ./gradlew bootRun --args='--server.port=8081'
 ```
 
@@ -58,7 +58,7 @@ Run a packaged JAR:
 ```bash
 ./gradlew bootJar
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
-LOGFRIENDS_INGEST_URL=http://localhost:8082/ingest \
+LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 java -Djdk.attach.allowAttachSelf=true \
      -jar build/libs/log-friends-examples-*.jar
 ```
@@ -173,7 +173,7 @@ Console owns Agent registration, LogSpec upsert, Raw Event storage, Log Catalog 
 | `spring.application.name` | `order-service` | Example app name |
 | `server.port` | `8081` | Example app port |
 | `logfriends.worker.id` | `order-service-local-1` | Fixed local Worker identifier |
-| `logfriends.ingest.url` | `http://localhost:8082/ingest` | Console ingest endpoint |
+| `logfriends.ingest.url` | `http://localhost:8080/ingest` | Console ingest endpoint |
 | `logfriends.trace.threshold.ms` | `0` | Show METHOD_TRACE in short example calls |
 
 | Environment variable | Description |

--- a/docs/log-catalog.md
+++ b/docs/log-catalog.md
@@ -22,7 +22,7 @@ appName=order-service
 ```
 
 ```bash
-curl -X POST http://localhost:8082/api/agents \
+curl -X POST http://localhost:8080/api/agents \
   -H 'Content-Type: application/json' \
   -d '{
     "workerId": "order-service-local-1",
@@ -40,7 +40,7 @@ The response contains an `id`. Use it as `<agentId>` below.
 The current Console API stores LogSpec snapshots by Agent:
 
 ```bash
-curl -X PUT http://localhost:8082/api/log-specs/by-agent/<agentId> \
+curl -X PUT http://localhost:8080/api/log-specs/by-agent/<agentId> \
   -H 'Content-Type: application/json' \
   -d '{
     "specs": [
@@ -134,7 +134,7 @@ Run the app with the same workerId:
 
 ```bash
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
-LOGFRIENDS_INGEST_URL=http://localhost:8082/ingest \
+LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 ./gradlew bootRun --args='--server.port=8081'
 ```
 
@@ -159,13 +159,13 @@ curl -X POST http://localhost:8081/users \
 Open the static UI:
 
 ```text
-http://localhost:8082/log-catalog
+http://localhost:8080/log-catalog
 ```
 
 Or query the API:
 
 ```bash
-curl 'http://localhost:8082/api/log-catalog/apps/order-service/events?workerId=order-service-local-1&sampleSize=5'
+curl 'http://localhost:8080/api/log-catalog/apps/order-service/events?workerId=order-service-local-1&sampleSize=5'
 ```
 
 Check:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=order-service
 server.port=8081
 
 # Console ingest endpoint for log-friends agent
-logfriends.ingest.url=${LOGFRIENDS_INGEST_URL:http://localhost:8082/ingest}
+logfriends.ingest.url=${LOGFRIENDS_INGEST_URL:http://localhost:8080/ingest}
 logfriends.worker.id=${LOGFRIENDS_WORKER_ID:order-service-local-1}
 
 # Interceptor toggles - set to false to disable individual interceptors


### PR DESCRIPTION
## Summary
- update examples ingest defaults to Console port 8080
- update README, AGENTS, and Log Catalog guide URLs from 8082 to 8080

## Validation
- ./gradlew build