### PR TITLE
feat: add SDK v0.3 LogSpec hint examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,16 @@
 
 LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
+LOGFRIENDS_APP_NAME=order-service \
+LOGFRIENDS_APP_VERSION=examples-v0.3.0 \
 java -Djdk.attach.allowAttachSelf=true \
-     -jar build/libs/examples.jar
+     -jar build/libs/log-friends-examples.jar
 ```
 
 ## 주의사항
 
 - Console 없이도 앱은 기동할 수 있지만 이벤트 전송은 실패 로그가 남을 수 있다.
 - `workerId`는 실행마다 바뀌는 자동값이 아니라 설정에서 고정 주입한다.
+- SDK `v0.3.0` 기준으로 Agent handshake 성공 후 Discovered `LOG_EVENT` 후보가 Console로 보고된다.
 - 테스트 환경에서는 `logfriends.agent.enabled=false` 권장.
 - 예제는 SDK 사용 패턴을 보여주는 목적이며 Console 저장/통계/Log Catalog 책임을 갖지 않는다.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,23 +6,17 @@ COPY gradlew gradlew.bat ./
 COPY gradle/ gradle/
 COPY gradle.properties settings.gradle.kts build.gradle.kts ./
 
-COPY log-friends-sdk/build.gradle.kts log-friends-sdk/
-COPY examples/build.gradle.kts examples/
-COPY spark-jobs/build.gradle.kts spark-jobs/
-
-COPY log-friends-sdk/src log-friends-sdk/src
-COPY examples/src examples/src
-COPY proto/ proto/
+COPY src src
 
 RUN chmod +x gradlew
 
-RUN ./gradlew :log-friends-sdk:jar :examples:bootJar --no-daemon
+RUN ./gradlew bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app
 
-COPY --from=builder /workspace/examples/build/libs/examples.jar app.jar
+COPY --from=builder /workspace/build/libs/log-friends-examples.jar app.jar
 
 EXPOSE 8081
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Spring Boot example application for the first-phase `log-friends-sdk` flow.
 
+This example uses `log-friends-sdk:v0.3.0`, including startup Agent handshake state and Discovered `LOG_EVENT` candidate reporting.
+
 The app demonstrates runtime capture for five SDK eventTypes:
 
 | eventType | Example source |
@@ -28,16 +30,18 @@ The example path uses the SDK library, HTTP ingest, and the Console without a se
 
 The SDK requires a fixed `workerId` and a Console ingest endpoint.
 
-This branch uses the SDK `main` baseline that enforces required configuration, camelCase `LOG_EVENT.eventName`, and `@LogMasked` handling.
+This branch uses the SDK `v0.3.0` baseline that enforces required configuration, camelCase `LOG_EVENT.eventName`, `@LogMasked` handling, Agent handshake state, and Discovered `LOG_EVENT` candidate reporting.
 
 ```bash
 export LOGFRIENDS_WORKER_ID=order-service-local-1
+export LOGFRIENDS_APP_NAME=order-service
+export LOGFRIENDS_APP_VERSION=examples-v0.3.0
 export LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest
 ```
 
 `workerId` identifies the running app instance. Do not generate a new value on every run if you want Console Agent metadata and statistics to stay connected.
 
-`application.properties` keeps `order-service-local-1` and `http://localhost:8080/ingest` as local example fallbacks. Set the environment variables explicitly when verifying Console integration.
+`application.properties` keeps `order-service-local-1`, `order-service`, and `http://localhost:8080/ingest` as local example fallbacks. Set the environment variables explicitly when verifying Console integration.
 
 ## Run With Console
 
@@ -49,6 +53,8 @@ Run the example app:
 git clone https://github.com/log-freind/log-friends-examples.git
 cd log-friends-examples
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
+LOGFRIENDS_APP_NAME=order-service \
+LOGFRIENDS_APP_VERSION=examples-v0.3.0 \
 LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 ./gradlew bootRun --args='--server.port=8081'
 ```
@@ -58,9 +64,11 @@ Run a packaged JAR:
 ```bash
 ./gradlew bootJar
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
+LOGFRIENDS_APP_NAME=order-service \
+LOGFRIENDS_APP_VERSION=examples-v0.3.0 \
 LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 java -Djdk.attach.allowAttachSelf=true \
-     -jar build/libs/log-friends-examples-*.jar
+     -jar build/libs/log-friends-examples.jar
 ```
 
 ## Run Against A Mock Ingest Endpoint
@@ -75,6 +83,8 @@ In another terminal:
 
 ```bash
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
+LOGFRIENDS_APP_NAME=order-service \
+LOGFRIENDS_APP_VERSION=examples-v0.3.0 \
 LOGFRIENDS_INGEST_URL=http://127.0.0.1:8089/ingest \
 ./gradlew bootRun --args='--server.port=8081'
 ```
@@ -88,7 +98,7 @@ The mock server prints each posted batch, its top-level `workerId`, and the even
 ```bash
 curl -X POST http://localhost:8081/orders \
   -H 'Content-Type: application/json' \
-  -d '{"productId":"PROD-1","quantity":2,"userId":"USR-1"}'
+  -d '{"productId":"PROD-1","quantity":2,"userId":"USR-1","customerEmail":"buyer@example.com","couponCode":"WELCOME10"}'
 ```
 
 Expected `LOG_EVENT.eventName`: `orderCreated`
@@ -100,7 +110,9 @@ Expected top-level payload fields. The service receives `OrderRequest` as a DTO,
   "request": {
     "productId": "PROD-1",
     "quantity": 2,
-    "userId": "USR-1"
+    "userId": "USR-1",
+    "customerEmail": "__MASKED__",
+    "couponCode": "WELCOME10"
   }
 }
 ```
@@ -152,13 +164,61 @@ Expected `LOG_EVENT.eventName` values: `userRegistered`, `userDeactivated`
 Example `@LogEvent` names use camelCase:
 
 ```kotlin
-@LogEvent("userRegistered")
-fun register(name: String, @LogMasked email: String): String
+@LogEvent(
+    name = "userRegistered",
+    description = "User registration business eventName",
+    apiMethod = "POST",
+    apiPath = "/users",
+    apiDescription = "Registers a new example user"
+)
+fun register(
+    @LogField(description = "Registered user display name", type = "STRING")
+    name: String,
+    @LogMasked
+    @LogField(description = "Registered user email. SDK sends __MASKED__", type = "STRING")
+    email: String
+): String
 ```
 
 The SDK skips invalid `LOG_EVENT.eventName` values and leaves a warning in the target app log. Dotted names such as `user.registered` are intentionally not used by this example.
 
 Method parameter names become top-level `LOG_EVENT.payload` keys. DTOs are not flattened by the SDK contract. For example, `OrderService.create(request: OrderRequest)` is sent as top-level `request`.
+
+DTO field masking is also demonstrated by `OrderRequest.customerEmail`:
+
+```kotlin
+data class OrderRequest(
+    /** Product identifier selected by the user. */
+    @field:LogField(description = "Product identifier selected by the user", type = "STRING")
+    val productId: String,
+    /** Number of products to order. */
+    @field:LogField(description = "Number of products to order", type = "INT")
+    val quantity: Int,
+    /** Example user identifier connected to the order. */
+    @field:LogField(description = "Example user identifier connected to the order", type = "STRING")
+    val userId: String,
+    /** Buyer email. Masked by SDK before transport. */
+    @field:LogMasked
+    @field:LogField(description = "Buyer email. Masked by SDK before transport", type = "STRING", required = false)
+    val customerEmail: String? = null,
+    /** Optional coupon code applied to the order. */
+    @field:LogField(description = "Optional coupon code applied to the order", type = "STRING", required = false)
+    val couponCode: String? = null
+)
+```
+
+## Discovered LOG_EVENT Candidates
+
+With SDK `v0.3.0`, the example app reports discovered `@LogEvent` candidates to Console after Agent handshake succeeds:
+
+```text
+ApplicationReadyEvent
+  -> POST /api/agents
+  -> scan loaded classes for @LogEvent
+  -> POST /api/agents/{agentId}/discovered-log-events
+```
+
+This means the Console can show candidate eventNames and annotation-based LogSpec hints even before a sample is generated by calling the endpoint. Discovered candidates are not confirmed LogSpecs. Backend owners still confirm or edit LogSpecs through Console APIs.
 
 ## LogSpec And Log Catalog
 
@@ -173,12 +233,15 @@ Console owns Agent registration, LogSpec upsert, Raw Event storage, Log Catalog 
 | `spring.application.name` | `order-service` | Example app name |
 | `server.port` | `8081` | Example app port |
 | `logfriends.worker.id` | `order-service-local-1` | Fixed local Worker identifier |
+| `logfriends.app.version` | `examples-v0.3.0` | Optional app version sent with discovered `LOG_EVENT` candidates |
 | `logfriends.ingest.url` | `http://localhost:8080/ingest` | Console ingest endpoint |
 | `logfriends.trace.threshold.ms` | `0` | Show METHOD_TRACE in short example calls |
 
 | Environment variable | Description |
 |---|---|
 | `LOGFRIENDS_WORKER_ID` | Overrides `logfriends.worker.id` |
+| `LOGFRIENDS_APP_NAME` | Overrides `spring.application.name` for SDK registration |
+| `LOGFRIENDS_APP_VERSION` | Overrides `logfriends.app.version` |
 | `LOGFRIENDS_INGEST_URL` | Overrides `logfriends.ingest.url` |
 
 ## Tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("com.github.log-freind:log-friends-sdk:v0.1.0")
+    implementation("com.github.log-freind:log-friends-sdk:v0.3.0")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
@@ -28,6 +28,10 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    jvmArgs("-Djdk.attach.allowAttachSelf=true", "-Dnet.bytebuddy.experimental=true")
+}
+
+tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
     jvmArgs("-Djdk.attach.allowAttachSelf=true", "-Dnet.bytebuddy.experimental=true")
 }
 

--- a/docs/log-catalog.md
+++ b/docs/log-catalog.md
@@ -2,11 +2,15 @@
 
 `log-friends-examples` does not register LogSpecs from SDK runtime code.
 
+With SDK `v0.3.0`, `log-friends-examples` reports Discovered `LOG_EVENT` candidates and annotation-based LogSpec hints after Agent handshake succeeds. These candidates help Console show known `@LogEvent` methods and suggested descriptions even before a sample exists.
+
 Use Console APIs to connect example `LOG_EVENT` Raw Events to Log Catalog:
 
 ```text
 @LogEvent in examples
-  -> SDK HTTP JSON POST /ingest
+  -> SDK Agent handshake POST /api/agents
+  -> SDK Discovered candidates POST /api/agents/{agentId}/discovered-log-events
+  -> SDK HTTP JSON POST /ingest when methods execute
   -> Console custom_events Raw Event
   -> Console Agent + LogSpec API
   -> Log Catalog Recent Sample + Mismatch + Field Request
@@ -53,7 +57,7 @@ curl -X PUT http://localhost:8080/api/log-specs/by-agent/<agentId> \
         "levels": ["INFO"],
         "category": "BUSINESS",
         "fields": [
-          {"name":"request","type":"JSON","required":true,"description":"OrderRequest DTO object. Includes productId, quantity, customerEmail, and couponCode when present. SDK keeps DTO parameters as object values instead of flattening fields"}
+          {"name":"request","type":"JSON","required":true,"description":"OrderRequest DTO object. SDK keeps DTO parameters as object values instead of flattening fields. productId means selected product identifier, quantity means ordered count, userId means ordering user identifier, customerEmail is masked as __MASKED__, and couponCode is an optional applied coupon code"}
         ]
       },
       {
@@ -134,6 +138,8 @@ Run the app with the same workerId:
 
 ```bash
 LOGFRIENDS_WORKER_ID=order-service-local-1 \
+LOGFRIENDS_APP_NAME=order-service \
+LOGFRIENDS_APP_VERSION=examples-v0.3.0 \
 LOGFRIENDS_INGEST_URL=http://localhost:8080/ingest \
 ./gradlew bootRun --args='--server.port=8081'
 ```
@@ -143,7 +149,7 @@ Trigger three `LOG_EVENT` samples:
 ```bash
 curl -X POST http://localhost:8081/orders \
   -H 'Content-Type: application/json' \
-  -d '{"productId":"PROD-1","quantity":2,"userId":"USR-1"}'
+  -d '{"productId":"PROD-1","quantity":2,"userId":"USR-1","customerEmail":"buyer@example.com","couponCode":"WELCOME10"}'
 
 curl -X POST http://localhost:8081/payments \
   -H 'Content-Type: application/json' \
@@ -170,9 +176,12 @@ curl 'http://localhost:8080/api/log-catalog/apps/order-service/events?workerId=o
 
 Check:
 
+- Discovered candidates appear after app startup, even before each eventName has a Recent Sample.
+- LogSpec Hints show annotation-provided event/API/field descriptions separately from confirmed LogSpec.
 - `orderCreated`, `paymentProcessed`, and `userRegistered` are connected by eventName.
 - LogSpec API context appears under the eventName when `apiMethod`, `apiPath`, or `apiDescription` is registered.
 - Field descriptions explain DTO payloads and scalar fields without requiring nested DTO schema support.
+- `OrderRequest.customerEmail` is masked by DTO field annotation before transport.
 - Recent Sample payloads come from `custom_events`.
 - `userRegistered.email` is masked before display.
 - Events emitted without a registered LogSpec appear as `NO_SPEC`.

--- a/src/main/kotlin/com/example/demo/order/OrderRequest.kt
+++ b/src/main/kotlin/com/example/demo/order/OrderRequest.kt
@@ -1,3 +1,33 @@
 package com.example.demo.order
 
-data class OrderRequest(val productId: String, val quantity: Int, val userId: String)
+import com.logfriends.agent.annotation.LogMasked
+import com.logfriends.agent.annotation.LogField
+
+/**
+ * Order creation request used to demonstrate DTO payload capture.
+ *
+ * SDK keeps this DTO as one top-level LOG_EVENT payload field named `request`.
+ * Top-level DTO fields can still be masked before transport.
+ */
+data class OrderRequest(
+    /** Product identifier selected by the user. */
+    @field:LogField(description = "Product identifier selected by the user", type = "STRING")
+    val productId: String,
+
+    /** Number of products to order. */
+    @field:LogField(description = "Number of products to order", type = "INT")
+    val quantity: Int,
+
+    /** Example user identifier connected to the order. */
+    @field:LogField(description = "Example user identifier connected to the order", type = "STRING")
+    val userId: String,
+
+    /** Buyer email. Masked by SDK before transport. */
+    @field:LogMasked
+    @field:LogField(description = "Buyer email. Masked by SDK before transport", type = "STRING", required = false)
+    val customerEmail: String? = null,
+
+    /** Optional coupon code applied to the order. */
+    @field:LogField(description = "Optional coupon code applied to the order", type = "STRING", required = false)
+    val couponCode: String? = null
+)

--- a/src/main/kotlin/com/example/demo/order/OrderService.kt
+++ b/src/main/kotlin/com/example/demo/order/OrderService.kt
@@ -1,6 +1,7 @@
 package com.example.demo.order
 
 import com.logfriends.agent.annotation.LogEvent
+import com.logfriends.agent.annotation.LogField
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -10,16 +11,36 @@ class OrderService(
 ) {
     private val log = LoggerFactory.getLogger(OrderService::class.java)
 
-    @LogEvent("orderCreated")
-    fun create(request: OrderRequest): String {
+    @LogEvent(
+        name = "orderCreated",
+        description = "Order creation business eventName",
+        apiMethod = "POST",
+        apiPath = "/orders",
+        apiDescription = "Creates an order from an OrderRequest DTO"
+    )
+    fun create(
+        @LogField(description = "OrderRequest DTO object", type = "JSON")
+        request: OrderRequest
+    ): String {
         log.info("Creating order for product {}, user {}", request.productId, request.userId)
         val orderId = "ORD-" + System.currentTimeMillis()
         orderAuditRepository.recordCreated(orderId, request.productId, request.quantity, request.userId)
         return orderId
     }
 
-    @LogEvent("orderCancelled")
-    fun cancel(orderId: String, reason: String) {
+    @LogEvent(
+        name = "orderCancelled",
+        description = "Order cancellation business eventName",
+        apiMethod = "DELETE",
+        apiPath = "/orders/{orderId}",
+        apiDescription = "Cancels an existing order with a reason"
+    )
+    fun cancel(
+        @LogField(description = "Cancelled order identifier", type = "STRING")
+        orderId: String,
+        @LogField(description = "Human-readable cancellation reason", type = "STRING")
+        reason: String
+    ) {
         log.warn("Canceling order {}, reason: {}", orderId, reason)
     }
 }

--- a/src/main/kotlin/com/example/demo/payment/PaymentService.kt
+++ b/src/main/kotlin/com/example/demo/payment/PaymentService.kt
@@ -1,6 +1,7 @@
 package com.example.demo.payment
 
 import com.logfriends.agent.annotation.LogEvent
+import com.logfriends.agent.annotation.LogField
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -8,14 +9,38 @@ import org.springframework.stereotype.Service
 class PaymentService {
     private val log = LoggerFactory.getLogger(PaymentService::class.java)
 
-    @LogEvent("paymentProcessed")
-    fun processPayment(orderId: String, amount: Int, method: String): String {
+    @LogEvent(
+        name = "paymentProcessed",
+        description = "Payment processed business eventName",
+        apiMethod = "POST",
+        apiPath = "/payments",
+        apiDescription = "Processes a payment for an order"
+    )
+    fun processPayment(
+        @LogField(description = "Order identifier connected to the payment", type = "STRING")
+        orderId: String,
+        @LogField(description = "Payment amount in the example request", type = "INT")
+        amount: Int,
+        @LogField(description = "Payment method such as CARD", type = "STRING")
+        method: String
+    ): String {
         log.info("Processing payment for order {} via {}", orderId, method)
         return "TX-" + System.currentTimeMillis()
     }
 
-    @LogEvent("paymentRefunded")
-    fun refund(txId: String, reason: String) {
+    @LogEvent(
+        name = "paymentRefunded",
+        description = "Payment refund business eventName",
+        apiMethod = "POST",
+        apiPath = "/payments/{transactionId}/refund",
+        apiDescription = "Refunds an existing payment transaction"
+    )
+    fun refund(
+        @LogField(description = "Refunded payment transaction identifier", type = "STRING")
+        txId: String,
+        @LogField(description = "Refund reason", type = "STRING")
+        reason: String
+    ) {
         log.info("Refunding transaction {}, reason: {}", txId, reason)
     }
 }

--- a/src/main/kotlin/com/example/demo/user/UserService.kt
+++ b/src/main/kotlin/com/example/demo/user/UserService.kt
@@ -1,6 +1,7 @@
 package com.example.demo.user
 
 import com.logfriends.agent.annotation.LogEvent
+import com.logfriends.agent.annotation.LogField
 import com.logfriends.agent.annotation.LogMasked
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -9,14 +10,35 @@ import org.springframework.stereotype.Service
 class UserService {
     private val log = LoggerFactory.getLogger(UserService::class.java)
 
-    @LogEvent("userRegistered")
-    fun register(name: String, @LogMasked email: String): String {
+    @LogEvent(
+        name = "userRegistered",
+        description = "User registration business eventName",
+        apiMethod = "POST",
+        apiPath = "/users",
+        apiDescription = "Registers a new example user"
+    )
+    fun register(
+        @LogField(description = "Registered user display name", type = "STRING")
+        name: String,
+        @LogMasked
+        @LogField(description = "Registered user email. SDK sends __MASKED__", type = "STRING")
+        email: String
+    ): String {
         log.info("Registering new user {}", name)
         return "USR-" + System.currentTimeMillis()
     }
 
-    @LogEvent("userDeactivated")
-    fun deactivate(userId: String) {
+    @LogEvent(
+        name = "userDeactivated",
+        description = "User deactivation business eventName",
+        apiMethod = "PUT",
+        apiPath = "/users/{userId}/deactivate",
+        apiDescription = "Deactivates an example user account"
+    )
+    fun deactivate(
+        @LogField(description = "Deactivated user identifier", type = "STRING")
+        userId: String
+    ) {
         log.warn("Deactivating user {}", userId)
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ server.port=8081
 # Console ingest endpoint for log-friends agent
 logfriends.ingest.url=${LOGFRIENDS_INGEST_URL:http://localhost:8080/ingest}
 logfriends.worker.id=${LOGFRIENDS_WORKER_ID:order-service-local-1}
+logfriends.app.version=${LOGFRIENDS_APP_VERSION:examples-v0.3.0}
 
 # Interceptor toggles - set to false to disable individual interceptors
 logfriends.interceptor.http.enabled=true


### PR DESCRIPTION
## Summary
- upgrade examples to `log-friends-sdk:v0.3.0`
- add `@LogEvent` API/description hints and `@LogField` field hints across Order, Payment, and User flows
- demonstrate DTO field masking with `OrderRequest.customerEmail`
- document Discovered `LOG_EVENT` candidate reporting and LogSpec Hint verification

## Why
SDK v0.3.0 reports annotation-based LogSpec hints after Agent handshake succeeds. The example app should show that flow clearly so Console Log Catalog can display candidates before every eventName has a Recent Sample.

## Validation
- `./gradlew build`

## Notes
- This PR is stacked on `chore/align-local-ports` to keep port/documentation alignment separate.
- Local `.env`, `.vscode`, and `bin/` changes were intentionally excluded.
